### PR TITLE
Updated training/faster_rcnn_inception_v2_pets.config

### DIFF
--- a/training/faster_rcnn_inception_v2_pets.config
+++ b/training/faster_rcnn_inception_v2_pets.config
@@ -89,10 +89,6 @@ train_config: {
         manual_step_learning_rate {
           initial_learning_rate: 0.0002
           schedule {
-            step: 0
-            learning_rate: .0002
-          }
-          schedule {
             step: 900000
             learning_rate: .00002
           }


### PR DESCRIPTION
Updated training/faster_rcnn_inception_v2_pets.config due to updates at Tensorflow Object Detection API. 
Thank you for the tutorial with great details!
Tried following it and training crashed with the following error:
raise ValueError('First step cannot be zero.')
Turns out they updated the code-  https://github.com/tensorflow/models/issues/3794